### PR TITLE
Applied hotfix according to issue #1 parent repo.

### DIFF
--- a/plugins/modules/cyberark_safe.py
+++ b/plugins/modules/cyberark_safe.py
@@ -398,7 +398,8 @@ def main():
             location=dict(type="str"),
             managing_cpm=dict(type="str"),
             number_of_versions_retention=dict(type="int"),
-            number_of_days_retention=dict(type="int", default=7),
+            #HOTFIX: See issue #1 on Parent Repository.
+            number_of_days_retention=dict(type="int"),
             auto_purge_enabled=dict(type="bool", default=False),
             logging_level=dict(
                 type="str", choices=["NOTSET", "DEBUG", "INFO"]


### PR DESCRIPTION
Temporary workaround to allow for versions safes to be built. Removed default argument for 7 Days of retention.